### PR TITLE
T49W Add the support for secrets as environment variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: clojure
 lein: 2.7.1
 script: |
     lein midje
-    lein deploy clojars
+    lein deploy clojar

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: clojure
 lein: 2.7.1
-script: lein midje
+script: lein do midje, deploy clojars

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: clojure
 lein: 2.7.1
-script: lein do midje, deploy clojars
+script: |
+    lein midje
+    lein deploy clojars

--- a/project.clj
+++ b/project.clj
@@ -13,6 +13,6 @@
                    :plugins [[lein-midje "3.2.1"]
                              [lein-auto "0.1.3"]]}}
   :repositories [["clojars" {:url "https://clojars.org/repo"
-                              :username [:gpg :env/clojar_username]
-                              :password [:gpg :env/clojar_password]}]]
+                             :username :env/clojar_username
+                             :password :env/clojar_password}]]
   :deploy-repositories [["clojars" :clojars]])

--- a/project.clj
+++ b/project.clj
@@ -12,4 +12,7 @@
   :profiles {:dev {:dependencies [[midje "1.9.2"]]
                    :plugins [[lein-midje "3.2.1"]
                              [lein-auto "0.1.3"]]}}
-  :deploy-repositories [["releases" :clojars]])
+  :repositories [["clojars" {:url "https://clojars.org/repo"
+                              :username [:gpg :env/clojar_username]
+                              :password [:gpg :env/clojar_password]}]]
+  :deploy-repositories [["clojars" :clojars]])

--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,6 @@
   :profiles {:dev {:dependencies [[midje "1.9.2"]]
                    :plugins [[lein-midje "3.2.1"]
                              [lein-auto "0.1.3"]]}}
-  :repositories [["clojars" {:url "https://clojars.org/repo"
-                             :username :env/clojar_username
-                             :password :env/clojar_password}]]
-  :deploy-repositories [["clojars" :clojars]])
+  :repositories [["clojar" {:url "https://clojars.org/repo"
+                             :username [:gpg :env/clojar_username]
+                             :password [:gpg :env/clojar_password]}]])

--- a/src/lambdakube/core.clj
+++ b/src/lambdakube/core.clj
@@ -91,6 +91,12 @@
    :metadata {:name name}
    :data m})
 
+(defn secret-key-ref
+  [k n optional?]
+  {:secretKeyRef {:key k
+                  :name n
+                  :optional optional?}})
+
 (defn add-container
   ([pod name image options]
    (let [container (-> options
@@ -102,8 +108,15 @@
 
 (defn add-env [container envs]
   (let [envs (for [[name val] envs]
-                           {:name name
-                            :value val})]
+               {:name name
+                :value val})]
+    (-> container
+        (update :env concat envs))))
+
+(defn add-env-value-from [container envs]
+  (let [envs (for [[name val] envs]
+               {:name name
+                :valueFrom val})]
     (-> container
         (update :env concat envs))))
 
@@ -404,7 +417,7 @@
                           (contains? (:spec node) :containers))
                    (update-in node [:spec :containers] #(map (fn [c]
                                                                (rule c (-> ctx
-                                                                                 (merge {:kind "Container"})))) %))
+                                                                           (merge {:kind "Container"})))) %))
                    ;; else
                    node))
                (fn [node rule ctx]
@@ -425,4 +438,3 @@
         nodes
         ;; else
         (recur nodes')))))
-


### PR DESCRIPTION
Add the support to use secrets as the value of environment variables. It uses `valueFrom` instead of `value` as the keyword so the existing `lambdakube.core/add-env` doesn't fit for the case. 

https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables
